### PR TITLE
ref mgigirey/iBeaconSwiftOSX#5

### DIFF
--- a/iBeaconSwiftOSX/CBBeaconTransmitter.swift
+++ b/iBeaconSwiftOSX/CBBeaconTransmitter.swift
@@ -46,7 +46,7 @@ final class CBBeaconTransmitter: NSObject, CBBeaconTransmitterProtocol {
     func startTransmitting() {
         if let advertisement = beaconData.beaconAdvertisement() {
             println(advertisement)
-            manager.startAdvertising(advertisement)
+            manager.startAdvertising(advertisement as [NSObject : AnyObject])
         }
     }
     


### PR DESCRIPTION
a suggestion for issue #5 that makes the project compile
beacons emmit correctly with a 2$ BLE usb dongle from aliexpress, after choosing the correct device with the Hardware IO Tools for XCode, as explained in http://apple.stackexchange.com/questions/94402/force-os-x-to-use-bluetooth-dongle-instead-of-built-in-controller
